### PR TITLE
Fix typo in type.rst

### DIFF
--- a/docs/references/phpdoc/types.rst
+++ b/docs/references/phpdoc/types.rst
@@ -25,7 +25,7 @@ ABNF
     class-name               = 1*CHAR
     keyword                  = "string"|"integer"|"int"|"boolean"|"bool"|"float"
                                |"double"|"object"|"mixed"|"array"|"resource"
-                               |"void"|"null"|"callback"|"false"|"true"|"self"
+                               |"void"|"null"|"callable"|"false"|"true"|"self"
 
 When a :term:`Type` is used the user will expect a value, or set of values, as
 detailed below.


### PR DESCRIPTION
「型の定義」ページの誤記を訂正しています。

phpDocumentor/phpDocumentor#2712 と同じ修正です。